### PR TITLE
fix: if not in bucket, bucket name param for testnet

### DIFF
--- a/src/libs/aws-s3-lib.js
+++ b/src/libs/aws-s3-lib.js
@@ -4,9 +4,9 @@ const Bucket = process.env.VERIFIED_CONTRACTS_BUCKET;
 const SOURCE_FILENAME = 'source.json';
 const METADATA_FILENAME = 'metadata.json'
 
-async function isVerified(contractAddress){
+async function isVerified(contractAddress, bucket = Bucket){
     let headInfo;
-    const params = { Bucket , Key: `${contractAddress}/${SOURCE_FILENAME}` };
+    const params = { Bucket: bucket , Key: `${contractAddress}/${SOURCE_FILENAME}` };
     try{
         await clientS3.headObject(params).promise();  
         return true;

--- a/src/libs/sourcify.mjs
+++ b/src/libs/sourcify.mjs
@@ -29,7 +29,7 @@ async function getSource(contractAddress, chainId){
 async function updateVerifiedContractsData(verifiedList,chainId, bucket){
   let newCount = 0;
   for (let address of verifiedList){
-    if(isVerified(address)){ //check if already in bucket
+    if(!isVerified(address, bucket)){ //check if already in bucket
       const source = await getSource(address, chainId);   
       const metadata = source.data.files.find(file => file.name === 'metadata.json');
       try{


### PR DESCRIPTION
- fix check for pre-existing contract & files in bucket 
- add bucket as param for testnet contracts