### PR TITLE
fix: rex payout based on balance ratio instead of total difference

### DIFF
--- a/src/v1-routes/chaininfo.js
+++ b/src/v1-routes/chaininfo.js
@@ -141,8 +141,6 @@ async function getApyStats() {
 
     const balanceRatio = rexTotal.eq(0) ? -1 : stlosTotal.times(fixedRatio).div(rexTotal.add(stlosTotal));
 
-
-
     if (balanceRatio.eq(0)) {
         return zeroBal;
     }
@@ -150,7 +148,7 @@ async function getApyStats() {
     const stlosPayout = annualPayout.times(balanceRatio);
     const evmApy = stlosPayout.div(stlosTotal).times(100).toFixed(2);
 
-    const rexPayout = annualPayout.minus(stlosPayout);
+    const rexPayout = annualPayout.times(1 - balanceRatio);
     const rexApy = rexPayout.div(rexTotal).times(100).toFixed(2);
 
     return  { native: rexApy, evm: evmApy };


### PR DESCRIPTION
# Fixes #39 

## Description
updates APY calculation to use product of balance ratios instead of total differences

## Test scenarios
`apy/evm` and `apy/native` should return the same value

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
