### PR TITLE
fix: update EVM RPC endpoints from mainnet.telos.net to rpc.telos.net

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -35,7 +35,7 @@ const envDev = {
   accountCreatorKey: 'tf-account-creator-key-dev',
   allowDeleteNumber: 'Y',
   marketdataTableName: 'dev-marketdata',
-  evmProvider:'https://testnet.telos.net/evm',
+  evmProvider:'https://rpc.testnet.telos.net',
   evmHyperionProvider: 'https://testnet.telos.net/v2/evm',  
   eosioApiEndPoint: 'https://testnet.telos.caleos.io',
   hyperionEndpoint: 'https://testnet.telos.caleos.io',
@@ -44,7 +44,7 @@ const envDev = {
   SERVER_PORT: 3000,
   TIME_SPAN: 5,
   STLOS_CONTRACT: '0xa9991e4daa44922d00a78b6d986cdf628d46c4dd',
-  NETWORK_EVM_RPC: 'https://testnet.telos.net/evm',
+  NETWORK_EVM_RPC: 'https://rpc.testnet.telos.net',
   EVM_CHAIN_ID: 41,
   
 };
@@ -57,7 +57,7 @@ const envProd = {
   accountCreatorKey: 'tf-account-creator-key-prod',
   marketdataTableName: 'prod-marketdata',
   allowDeleteNumber: 'N',
-  evmProvider:'https://mainnet.telos.net/evm',
+  evmProvider:'https://rpc.telos.net',
   evmHyperionProvider: 'https://mainnet.telos.net/v2/evm',  
   eosioApiEndPoint: 'https://telos.caleos.io',
   hyperionEndpoint: 'https://telos.caleos.io',
@@ -66,7 +66,7 @@ const envProd = {
   SERVER_PORT: 4000,
   TIME_SPAN: 10080,
   STLOS_CONTRACT: '0xb4b01216a5bc8f1c8a33cd990a1239030e60c905',
-  NETWORK_EVM_RPC: 'https://mainnet.telos.net/evm',
+  NETWORK_EVM_RPC: 'https://rpc.telos.net',
   EVM_CHAIN_ID: 40,
 };
 


### PR DESCRIPTION
- Production: mainnet.telos.net/evm → rpc.telos.net
- Development: testnet.telos.net/evm → rpc.testnet.telos.net

The old endpoints are no longer available (returning 404/503). This fixes the APY endpoint which was failing to fetch staking data.